### PR TITLE
Enable parallel test execution for faster builds

### DIFF
--- a/src/main/java/org/vaadin/addons/dramafinder/AbstractBasePlaywrightIT.java
+++ b/src/main/java/org/vaadin/addons/dramafinder/AbstractBasePlaywrightIT.java
@@ -33,12 +33,12 @@ public abstract class AbstractBasePlaywrightIT implements HasTestView {
     // @formatter:on
 
     protected Page page;
-    protected static Playwright playwright;
-    protected static Browser browser;
+    private static final ThreadLocal<Playwright> playwright = new ThreadLocal<>();
+    private static final ThreadLocal<Browser> browser = new ThreadLocal<>();
 
     @BeforeEach
     public void setupTest() throws Exception {
-        page = browser.newPage();
+        page = browser.get().newPage();
         page.navigate(getUrl() + getView());
         page.waitForFunction(WAIT_FOR_VAADIN_SCRIPT);
         page.setDefaultNavigationTimeout(4000);
@@ -52,19 +52,36 @@ public abstract class AbstractBasePlaywrightIT implements HasTestView {
 
     @AfterAll
     public static void cleanup() {
-        browser.close();
-        playwright.close();
+        Browser b = browser.get();
+        Playwright p = playwright.get();
+        if (b != null) {
+            b.close();
+            browser.remove();
+        }
+        if (p != null) {
+            p.close();
+            playwright.remove();
+        }
     }
 
     @BeforeAll
     public static void setup() {
-        playwright = Playwright.create();
-        browser = playwright.chromium().launch(new LaunchOptions()
-                .setHeadless(isHeadless()));
+        Playwright p = Playwright.create();
+        playwright.set(p);
+        browser.set(p.chromium().launch(new LaunchOptions()
+                .setHeadless(isHeadless())));
     }
 
     protected Page getPage() {
         return page;
+    }
+
+    protected Browser getBrowser() {
+        return browser.get();
+    }
+
+    protected Playwright getPlaywright() {
+        return playwright.get();
     }
 
     protected void event(Locator locator, String type, Object eventInit,

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,10 @@
+# Enable parallel test execution
+junit.jupiter.execution.parallel.enabled=true
+
+# Run test classes in parallel, but methods within a class sequentially
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent
+
+# Use half the available CPU cores - balances speed vs resource contention
+junit.jupiter.execution.parallel.config.strategy=dynamic
+junit.jupiter.execution.parallel.config.dynamic.factor=0.5


### PR DESCRIPTION
Use ThreadLocal for Playwright/Browser instances to allow test classes to run concurrently. Configure JUnit 5 to run classes in parallel using half the available CPU cores for a balance of speed and stability.
