### PR TITLE
Clarify AbstractBasePlaywrightIT is optional in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,105 @@ public void testHelper() {
 
 ```
 
+## Getting started
+
+Add the addon as a test dependency.
+
+```xml
+
+<dependency>
+    <groupId>org.vaadin.addons</groupId>
+    <artifactId>dramafinder</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <scope>test</scope>
+</dependency>
+```
+
+The Drama Finder element classes are built around a plain Playwright `Page`
+(or `Locator`). They have no dependency on any particular test base class, so
+you can use them with whatever Playwright setup you already have. Just hand a
+`Page` to the factory helpers (e.g. `getByLabel`) or to an element constructor.
+
+The simplest way to get started is to let Spring Boot start the server for you
+with `@SpringBootTest(webEnvironment = RANDOM_PORT)` and manage the Playwright
+`Page` yourself:
+
+```java
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public class SimpleExampleViewIT {
+
+    @LocalServerPort
+    private int port;
+
+    Playwright playwright;
+    Browser browser;
+    Page page;
+
+    @BeforeEach
+    public void setup() {
+        playwright = Playwright.create();
+        browser = playwright.chromium().launch();
+        page = browser.newPage();
+        page.navigate(String.format("http://localhost:%d/", port));
+    }
+
+    @AfterEach
+    public void tearDown() {
+        browser.close();
+        playwright.close();
+    }
+
+    @Test
+    public void testTooltip() {
+        // The only thing the element API needs is a Playwright Page
+        TextFieldElement textfield = TextFieldElement.getByLabel(page, "Textfield");
+        textfield.assertVisible();
+        textfield.assertTooltipHasText("Tooltip for textfield");
+    }
+}
+```
+
+Letting `@SpringBootTest` start the server is not the only option. You can also
+write the tests as plain integration tests (e.g. classes ending in `IT.java`
+run by the `maven-failsafe-plugin`) and start/stop the server separately with
+Maven — for example using the `spring-boot:start` and `spring-boot:stop` goals
+bound to the `pre-integration-test` / `post-integration-test` phases — before
+the ITs execute. In that case the test simply navigates to the externally
+started server's URL. Either way, the element API only ever needs a Playwright
+`Page`, so you are free to obtain it however suits your project.
+
+### Optional: `AbstractBasePlaywrightIT` convenience base class
+
+If you don't already have a Playwright setup, Drama Finder ships an optional
+`AbstractBasePlaywrightIT` base class that handles the boilerplate for you:
+creating and closing the `Playwright`/`Browser`, opening a fresh `page` and
+navigating to your view before each test, headless toggling, and a few helper
+interaction methods (`click`, `fill`, `press`, ...). Extending it is purely a
+convenience — it is never required to use the element API.
+
+```java
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public class SimpleExampleViewIT extends AbstractBasePlaywrightIT {
+
+    @LocalServerPort
+    private int port;
+
+    @Override
+    public String getUrl() {
+        return String.format("http://localhost:%d/", port);
+    }
+
+    @Test
+    public void testTooltip() {
+        TextFieldElement textfield = TextFieldElement.getByLabel(page, "Textfield");
+        textfield.assertVisible();
+        textfield.assertTooltipHasText("Tooltip for textfield");
+    }
+}
+```
+
 ## Note
 
 The API is in early stage of development.
@@ -131,44 +230,6 @@ You will need to add the profile in your pom.xml:
     </properties>
 </profile>
 
-```
-
-## How to use it
-
-Add the addon as a test dependency.
-
-```xml
-
-<dependency>
-    <groupId>org.vaadin.addons</groupId>
-    <artifactId>dramafinder</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <scope>test</scope>
-</dependency>
-```
-
-With Spring Boot you can create a simple test:
-
-```java
-
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-public class SimpleExampleViewIT extends AbstractBasePlaywrightIT {
-
-    @LocalServerPort
-    private int port;
-
-    @Override
-    public String getUrl() {
-        return String.format("http://localhost:%d/", port);
-    }
-
-    @Test
-    public void testTooltip() {
-        TextFieldElement textfield = TextFieldElement.getByLabel(page, "Textfield");
-        textfield.assertVisible();
-        textfield.assertTooltipHasText("Tooltip for textfield");
-    }
-}
 ```
 
 ## Cutting a release

--- a/README.md
+++ b/README.md
@@ -117,8 +117,9 @@ started server's URL. Either way, the element API only ever needs a Playwright
 If you don't already have a Playwright setup, Drama Finder ships an optional
 `AbstractBasePlaywrightIT` base class that handles the boilerplate for you:
 creating and closing the `Playwright`/`Browser`, opening a fresh `page` and
-navigating to your view before each test, headless toggling, and a few helper
-interaction methods (`click`, `fill`, `press`, ...). Extending it is purely a
+navigating to your view before each test, waiting for Vaadin to finish loading,
+sensible default timeouts, and headless toggling (via the `headless` system
+property or `HEADLESS` environment variable). Extending it is purely a
 convenience — it is never required to use the element API.
 
 ```java

--- a/src/main/java/org/vaadin/addons/dramafinder/AbstractBasePlaywrightIT.java
+++ b/src/main/java/org/vaadin/addons/dramafinder/AbstractBasePlaywrightIT.java
@@ -2,8 +2,6 @@ package org.vaadin.addons.dramafinder;
 
 import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.BrowserType.LaunchOptions;
-import com.microsoft.playwright.Locator;
-import com.microsoft.playwright.Locator.DispatchEventOptions;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
 import org.junit.jupiter.api.AfterAll;
@@ -82,43 +80,6 @@ public abstract class AbstractBasePlaywrightIT implements HasTestView {
 
     protected Playwright getPlaywright() {
         return playwright.get();
-    }
-
-    protected void event(Locator locator, String type, Object eventInit,
-                         DispatchEventOptions options) {
-        locator.nth(0).dispatchEvent(type, eventInit, options);
-        getPage().waitForTimeout(10);
-    }
-
-    protected void event(Locator locator, String eventName) {
-        locator.nth(0).dispatchEvent(eventName);
-        getPage().waitForTimeout(10);
-    }
-
-    protected void click(Locator locator) {
-        if (!locator.nth(0).locator("input").all().isEmpty()) {
-            locator = locator.nth(0).locator("input");
-        }
-        locator.nth(0).click();
-        getPage().waitForTimeout(10);
-    }
-
-    protected void press(Locator locator, String key) {
-        locator.nth(0).press(key);
-        getPage().waitForTimeout(10);
-    }
-
-    protected void fill(Locator locator, String value) {
-        if (!locator.first().locator("input").all().isEmpty()) {
-            locator = locator.first().locator("input");
-        }
-        locator.nth(0).fill(value);
-        locator.nth(0).blur();
-        getPage().waitForTimeout(10);
-    }
-
-    protected void select(Locator locator, String val) {
-        fill(locator, val);
     }
 
     protected static boolean isHeadless() {


### PR DESCRIPTION
Make the no-superclass setup the primary "How to use it" example, using @SpringBootTest to start the server while managing the Playwright Page directly, and note the alternative of running plain ITs with the server started/stopped via Maven. AbstractBasePlaywrightIT is now documented as an optional convenience base class.

Also changed this section into "getting started" and moved on top of instructions related to developing the library itself.