### PR TITLE
Exclude MCP config from the installable plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "vaadin-playwright-test",
-      "source": "./",
+      "source": "./skills/vaadin-playwright-test",
       "description": "Generate Playwright integration tests for Vaadin views using the DramaFinder library."
     }
   ]

--- a/.mcp.json
+++ b/.mcp.json
@@ -7,18 +7,6 @@
     "JavaDocs": {
       "type": "http",
       "url": "https://www.javadocs.dev/mcp"
-    },
-    "codebase-memory-mcp": {
-      "type": "stdio",
-      "command": "/Users/jean-christophe/.local/bin/codebase-memory-mcp"
-    },
-    "tessl": {
-      "type": "stdio",
-      "command": "tessl",
-      "args": [
-        "mcp",
-        "start"
-      ]
     }
   }
 }

--- a/skills/vaadin-playwright-test/.claude-plugin/plugin.json
+++ b/skills/vaadin-playwright-test/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vaadin-playwright-test",
   "description": "Generate Playwright integration tests for Vaadin views using the DramaFinder library — element interaction, form validation, grid assertions, and navigation checks.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "jcgueriaud1"
   },

--- a/tile.json
+++ b/tile.json
@@ -1,6 +1,6 @@
 {
   "name": "dramafinder/vaadin-playwright-test",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": false,
   "summary": "Generate Playwright integration tests for Vaadin 25 views using the DramaFinder library. Use when the user wants to write IT tests for a Vaadin view, mentions DramaFinder, or asks about Playwright testing in a Vaadin project.",
   "skills": {


### PR DESCRIPTION
## Problem

The marketplace plugin used `"source": "./"`, so the **plugin root was the repo root**. Claude Code auto-loads `.mcp.json` from the plugin root, so installing the plugin also started the `vaadin` and `JavaDocs` MCP servers — but those are only useful when developing dramafinder itself, not when using the skill.

## Fix

Point the plugin `source` at the skill directory so its root no longer contains `.mcp.json`. The `SKILL.md` there loads as the plugin's single skill (frontmatter `name: vaadin-playwright-test`), and `.mcp.json` stays at the repo root for local dev only.

- `marketplace.json`: `source` `./` → `./skills/vaadin-playwright-test`
- move `plugin.json` into `skills/vaadin-playwright-test/.claude-plugin/`
- bump version `0.1.0` → `0.2.0` (`plugin.json` + `tile.json`) so existing installs see an update
- drop dev-only `codebase-memory-mcp` and `tessl` entries from `.mcp.json`

The canonical `skills/vaadin-playwright-test/` path is unchanged, so Tessl (`tile.json`), the api-reference generator, CI, and docs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)