### PR TITLE
Make the skill trigger reliably: broader description, dependency-detection hook, doc fixes

### DIFF
--- a/skills/vaadin-playwright-test/.claude-plugin/plugin.json
+++ b/skills/vaadin-playwright-test/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vaadin-playwright-test",
   "description": "Generate Playwright integration tests for Vaadin views using the DramaFinder library — element interaction, form validation, grid assertions, and navigation checks.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "jcgueriaud1"
   },

--- a/skills/vaadin-playwright-test/SKILL.md
+++ b/skills/vaadin-playwright-test/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vaadin-playwright-test
-description: Generate Playwright integration tests for Vaadin 25 views using the DramaFinder library, including element interaction, form validation, grid assertions, and navigation checks. Use when the user wants to write IT tests for a Vaadin view, mentions DramaFinder, or asks about Playwright testing in a Vaadin project.
+description: Generate Playwright integration tests for Vaadin 25 views using the DramaFinder library, including element interaction, form validation, grid assertions, and navigation checks. Use whenever you are about to write, edit, or run an integration/IT test for a Vaadin view — including when the requirement comes from a GitHub issue, PR, spec, or ticket rather than the user's direct words (e.g. "implement #85", "fix the failing test", "add coverage for this view"). Also use when the user mentions DramaFinder, Playwright, `SpringPlaywrightIT`, `@PlaywrightElement`, files under `src/test/**/tests/it/`, or asks about Playwright testing in a Vaadin project. If a task in a Vaadin project involves any Playwright/IT test, load this skill before writing the test.
 ---
 
 # Vaadin Playwright Test Generator (DramaFinder)

--- a/skills/vaadin-playwright-test/SKILL.md
+++ b/skills/vaadin-playwright-test/SKILL.md
@@ -69,8 +69,9 @@ If no existing IT tests exist, use the default structure in Step 3.
 
 Read the target view source provided by the user. Extract:
 
-- `@Route("value")` → URL path (default: class name lowercased, stripped of
-  `View` suffix, e.g. `PersonView` → `/person`).
+- `@Route("value")` → URL path (default when no value: class name lowercased,
+  stripped of `View` suffix, e.g. `PersonView` → `/person`; `MainView` and
+  `Main` map to `/`).
 - `@PageTitle("...")` → expected page title
 - Every interactive component → its DramaFinder wrapper (see table below).
 - Form fields → label text used as locator.
@@ -80,7 +81,10 @@ Read the target view source provided by the user. Extract:
 See [element-mapping.md](element-mapping.md) for the full component → element
 class table, and [api-reference.md](api-reference.md) for the **complete public
 API** (every element, its methods, signatures and one-line descriptions) of the
-version you have installed.
+DramaFinder version bundled with this skill (see the version in its header). If
+the project pins an older `<dramafinder.version>`, a method documented there may
+not exist yet — if a call fails to compile, check the project's version before
+looking for alternatives.
 
 > **Never download or unzip the DramaFinder jar/sources to discover its API.**
 > The complete, always-current signature reference is bundled beside this skill
@@ -120,18 +124,17 @@ leaderboardGrid.assertCellContent(0, "Score", "100");
 leaderboardGrid.assertRowCount(10);
 ```
 
-The same rule applies to every wrapped component: `ComboBoxElement.selectByText()`
-not `combo.locator("vaadin-combo-box-item")`; `MenuBarElement.clickItem()` not
-a raw `vaadin-menu-bar-button` locator; and so on.
+The same rule applies to every wrapped component:
+`ComboBoxElement.selectItem()` not `combo.locator("vaadin-combo-box-item")`;
+`MenuBarElement.getMenuItemElement("File").click()` not a raw
+`vaadin-menu-bar-button` locator; and so on.
 
 ## Step 3 — Generate the test class
 
 ### Default structure (no existing tests to mirror)
 
 ```java
-package
-
-<same.package.as.view>; // mirror src/test/java structure
+package <same.package.as.view>; // mirror src/test/java structure
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -142,21 +145,17 @@ import <basePackage>.it.support.SpringPlaywrightIT; // Spring projects: actual l
 // import org.vaadin.addons.dramafinder.AbstractBasePlaywrightIT; // non-Spring projects
 
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-// omit if not Spring Boot
-public class <ViewName>IT extends
-
-SpringPlaywrightIT { // or AbstractBasePlaywrightIT
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT) // omit if not Spring Boot
+public class <ViewName>IT extends SpringPlaywrightIT { // or AbstractBasePlaywrightIT
 
     @Override
-    public String getView () {
+    public String getView() {
         return "/<route-path>";
     }
 
     @Test
-    public void testTitle () {
+    public void testTitle() {
         assertThat(page).hasTitle("<PageTitle value>");
     }
 
@@ -172,24 +171,14 @@ otherwise.
 **Smoke test (one per component):**
 
 ```java
-    @Test
-public void test<ComponentLabel>(){
-TextFieldElement field = TextFieldElement.getByLabel(page, "My Label");
-    field.
-
-assertVisible();
-    field.
-
-assertLabel("My Label");
-    field.
-
-assertValue("");
-    field.
-
-setValue("test value");
-    field.
-
-assertValue("test value");
+@Test
+public void test<ComponentLabel>() {
+    TextFieldElement field = TextFieldElement.getByLabel(page, "My Label");
+    field.assertVisible();
+    field.assertLabel("My Label");
+    field.assertValue("");
+    field.setValue("test value");
+    field.assertValue("test value");
 }
 ```
 
@@ -229,20 +218,25 @@ public void testGridLoadsData() {
 }
 ```
 
-## Step 4 — Show generated test, then confirm before writing
+## Step 4 — Write the test
 
-Display the full generated test class in a code block. Then ask:
+Place the test in `src/test/java` mirroring the view's package under
+`src/main/java`.
 
-> Shall I write this to `src/test/java/<package>/<ViewName>IT.java`?
+- **Interactive session** (the user asked for a test in conversation): display
+  the full generated test class in a code block first, then ask:
+  > Shall I write this to `src/test/java/<package>/<ViewName>IT.java`?
 
-Only write the file after explicit confirmation. Place it in `src/test/java`
-mirroring the view's package under `src/main/java`.
+  Only write the file after confirmation.
+- **Autonomous execution** (implementing an issue/PR/spec, or running
+  unattended): write the file directly without asking.
 
-## Step 5 — Offer to run the test
+## Step 5 — Run the test
 
-After writing, ask:
+Run with `mvn verify -Dit.test=<ViewName>IT`.
 
-> Do you want me to run this test now with `mvn verify -Dit.test=<ViewName>IT`?
-
-**Warn the user**: the first Vaadin frontend build takes 3–5 minutes. Subsequent
-runs are ~25 seconds.
+- **Interactive session**: offer to run it first — the first Vaadin frontend
+  build takes 3–5 minutes (subsequent runs are ~25 seconds), so let the user
+  decide.
+- **Autonomous execution**: run it directly and fix any failures before
+  finishing.

--- a/skills/vaadin-playwright-test/TESTING.md
+++ b/skills/vaadin-playwright-test/TESTING.md
@@ -7,7 +7,7 @@ description: Best practices for writing Playwright integration tests in this pro
 
 ## Guiding Principles
 
-- **Page Object Model (POM):** All tests should use the Page Object Model. Interactions with the UI should be encapsulated in page objects, and tests should only call methods on these page objects. This isolates the tests from changes in the UI. The page objects are the drama finder elements in `src/main/java/org/vaadin/addons/dramafinder/element`.
+- **Page Object Model (POM):** All tests should use the Page Object Model. Interactions with the UI should be encapsulated in page objects, and tests should only call methods on these page objects. This isolates the tests from changes in the UI. The page objects are the DramaFinder element wrappers from the library (package `org.vaadin.addons.dramafinder.element`), plus any custom `*Element` classes in the project's own sources.
 
 - **One Test, One Assert:** Each test method should test a single, specific piece of functionality. This makes tests easier to understand and debug.
 

--- a/skills/vaadin-playwright-test/element-mapping.md
+++ b/skills/vaadin-playwright-test/element-mapping.md
@@ -4,53 +4,54 @@ Use this table to map Vaadin component class names found in view source to the c
 
 Also scan `src/main/java` for any `*Element.java` files not listed here (custom extensions).
 
-> **The `Key Methods` column is illustrative, not authoritative.** Factory
-> methods are **not** uniform across elements — the factory name shown here may
-> be out of date. For the exact, always-current factory signatures of each
-> element, use the auto-generated **Element index** at the top of
-> [api-reference.md](api-reference.md) (derived directly from source, verified in
-> CI). Never assume a factory that isn't listed there.
+> The `Key Methods` column below is verified against the bundled
+> [api-reference.md](api-reference.md) but abbreviated — it lists the most
+> common factories and methods, not everything. The auto-generated **Element
+> index** at the top of [api-reference.md](api-reference.md) (derived directly
+> from source, verified in CI) is the authoritative list of factories, and each
+> element's section there is the authoritative list of methods. Never use a
+> method that isn't in api-reference.md.
 
 | Vaadin Component | DramaFinder Element Class | Key Methods |
 |-----------------|--------------------------|-------------|
-| `TextField` | `TextFieldElement` | `getByLabel(page, label)`, `setValue()`, `assertValue()`, `assertValid()`, `assertInvalid()`, `assertErrorMessage()`, `assertLabel()`, `assertPlaceholder()`, `assertHelperHasText()`, `assertPrefixHasText()`, `assertSuffixHasText()`, `assertClearButtonVisible()`, `clickClearButton()`, `assertTheme()`, `assertAllowedCharPattern()`, `assertMinLength()`, `assertMaxLength()`, `assertPattern()`, `assertTooltipHasText()`, `assertAriaLabel()`, `assertIsFocused()`, `assertEnabled()`, `assertDisabled()` |
-| `TextArea` | `TextAreaElement` | `getByLabel(page, label)`, `setValue()`, `assertValue()`, `assertValid()`, `assertInvalid()` |
-| `EmailField` | `EmailFieldElement` | `getByLabel(page, label)`, `setValue()`, `assertValue()`, `assertValid()`, `assertInvalid()` |
-| `PasswordField` | `PasswordFieldElement` | `getByLabel(page, label)`, `setValue()`, `assertValue()` |
-| `NumberField` | `NumberFieldElement` | `getByLabel(page, label)`, `setValue()`, `assertValue()` |
-| `IntegerField` | `IntegerFieldElement` | `getByLabel(page, label)`, `setValue()`, `assertValue()` |
+| `TextField` | `TextFieldElement` | `getByLabel(page, label)`, `setValue()`, `assertValue()`, `assertValid()`, `assertInvalid()`, `assertErrorMessage()`, `assertLabel()`, `assertPlaceholder()`, `assertHelperHasText()`, `assertMinLength()`, `assertMaxLength()`, `assertPattern()`, `clickClearButton()` |
+| `TextArea` | `TextAreaElement` | `getByLabel(page, label)`, `setValue()`, `assertValue()` — extends `TextFieldElement` |
+| `EmailField` | `EmailFieldElement` | `getByLabel(page, label)`, `setValue()`, `assertValue()` — extends `TextFieldElement` |
+| `PasswordField` | `PasswordFieldElement` | `getByLabel(page, label)`, `setValue()`, `assertValue()` — extends `TextFieldElement` |
+| `NumberField` | `NumberFieldElement` | `getByLabel(page, label)`, `setValue()`, `assertValue()`, `assertMin()`, `assertMax()`, `assertStep()`, `clickIncreaseButton()`, `clickDecreaseButton()` |
+| `IntegerField` | `IntegerFieldElement` | `getByLabel(page, label)`, `setValue()`, `assertValue()`, `assertMin()`, `assertMax()`, `assertStep()` |
 | `BigDecimalField` | `BigDecimalFieldElement` | `getByLabel(page, label)`, `setValue()`, `assertValue()` |
-| `Button` | `ButtonElement` | `getByText(page, text)`, `get(page)`, `click()`, `assertVisible()`, `assertEnabled()`, `assertDisabled()` |
-| `Checkbox` | `CheckboxElement` | `getByLabel(page, label)`, `check()`, `uncheck()`, `assertChecked()`, `assertUnchecked()` |
-| `RadioButtonGroup` | `RadioButtonGroupElement` | `getByLabel(page, label)`, `selectByText()`, `assertSelectedValue()` |
-| `ComboBox` | `ComboBoxElement` | `getByLabel(page, label)`, `selectByText()`, `assertValue()`, `openDropdown()` |
-| `MultiSelectComboBox` | `MultiSelectComboBoxElement` | `getByLabel(page, label)`, `selectByText()`, `assertSelectedValues()` |
-| `Select` | `SelectElement` | `getByLabel(page, label)`, `selectByText()`, `assertValue()` |
-| `ListBox` | `ListBoxElement` | `get(page)`, `selectByText()`, `assertSelectedValue()` |
-| `DatePicker` | `DatePickerElement` | `getByLabel(page, label)`, `setValue()`, `assertValue()`, `assertValid()`, `assertInvalid()` |
-| `TimePicker` | `TimePickerElement` | `getByLabel(page, label)`, `setValue()`, `assertValue()` |
-| `DateTimePicker` | `DateTimePickerElement` | `getByLabel(page, label)`, `setValue()`, `assertValue()` |
-| `Grid` | `GridElement` | `get(page)`, `assertRowCount()`, `assertCellContent(row, col, text)`, `clickRow()`, `sortByColumn()`, `selectRow()`, `assertRowSelected()` |
-| `TreeGrid` | `TreeGridElement` | `get(page)`, `expandRow()`, `collapseRow()`, `assertRowCount()`, `assertCellContent()` |
-| `VirtualList` | `VirtualListElement` | `get(page)`, `assertItemCount()` |
-| `Dialog` | `DialogElement` | `get(page)`, `assertOpen()`, `assertClosed()`, `getLocator()` |
-| `Notification` | `NotificationElement` | `get(page)`, `assertVisible()`, `assertText()` |
-| `Tabs` / `Tab` | `TabElement` | `getByLabel(page, label)`, `click()`, `assertSelected()` |
-| `TabSheet` | `TabSheetElement` | `get(page)`, `selectTabByLabel()`, `assertTabSelected()` |
-| `Accordion` | `AccordionElement` | `get(page)`, `openPanel()`, `closePanel()`, `assertPanelOpen()` |
-| `AccordionPanel` | `AccordionPanelElement` | `get(page)`, `assertOpen()`, `assertClosed()` |
-| `Details` | `DetailsElement` | `get(page)`, `open()`, `close()`, `assertOpen()`, `assertClosed()` |
-| `MenuBar` | `MenuBarElement` | `get(page)`, `clickItem()` |
-| `ContextMenu` | `ContextMenuElement` | `get(page)`, `open()`, `clickItem()` |
-| `SplitLayout` | `SplitLayoutElement` | `get(page)`, `assertOrientation()` |
-| `Upload` | `UploadElement` | `get(page)`, `uploadFile()`, `assertFileUploaded()` |
-| `ProgressBar` | `ProgressBarElement` | `get(page)`, `assertValue()`, `assertIndeterminate()` |
-| `Avatar` | `AvatarElement` | `get(page)`, `assertName()`, `assertAbbreviation()` |
-| `MessageInput` | `MessageInputElement` | `get(page)`, `sendMessage()` |
-| `MessageList` | `MessageListElement` | `get(page)`, `assertMessageCount()`, `assertMessageText()` |
-| `Popover` | `PopoverElement` | `get(page)`, `assertOpen()`, `assertClosed()` |
-| `SideNavigation` | `SideNavigationElement` | `get(page)`, `clickItem()`, `assertItemSelected()` |
-| `Card` | `CardElement` | `get(page)`, `assertVisible()`, `getText()` |
+| `Button` | `ButtonElement` | `getByText(page, text)`, `click()`, `assertVisible()`, `assertEnabled()`, `assertDisabled()` |
+| `Checkbox` | `CheckboxElement` | `getByLabel(page, label)`, `check()`, `uncheck()`, `assertChecked()`, `assertNotChecked()`, `assertIndeterminate()` |
+| `RadioButtonGroup` | `RadioButtonGroupElement` | `getByLabel(page, label)`, `selectByLabel()`, `selectByValue()`, `assertValue()` |
+| `ComboBox` | `ComboBoxElement` | `getByLabel(page, label)`, `selectItem()`, `filterAndSelectItem()`, `assertValue()`, `open()`, `assertItemCount()` |
+| `MultiSelectComboBox` | `MultiSelectComboBoxElement` | `getByLabel(page, label)`, `selectItem()`, `selectItems()`, `deselectItem()`, `assertSelectedItems()`, `assertSelectedCount()` |
+| `Select` | `SelectElement` | `getByLabel(page, label)`, `selectItem()`, `assertValue()` |
+| `ListBox` | `ListBoxElement` | `getByLabel(page, label)`, `selectItem()`, `assertSelectedValue()`, `assertItemEnabled()`, `assertItemDisabled()` |
+| `DatePicker` | `DatePickerElement` | `getByLabel(page, label)`, `setValue(LocalDate)`, `assertValue(LocalDate)`, `assertValid()`, `assertInvalid()` |
+| `TimePicker` | `TimePickerElement` | `getByLabel(page, label)`, `setValue(LocalTime)`, `assertValue(LocalTime)` |
+| `DateTimePicker` | `DateTimePickerElement` | `getByLabel(page, label)`, `setValue(LocalDateTime)`, `assertValue(LocalDateTime)`, `setDate()`, `setTime()` |
+| `Grid` | `GridElement` | `get(page)`, `getById(page, id)`, `assertRowCount()`, `assertCellContent(row, col, text)`, `assertHeaderCellContents()`, `select(rowIndex)`, `assertRowSelected()`, `scrollToRow()`, `findRow()`, `findCell()`; sorting via `findHeaderCellByText(text)` → `HeaderCellElement.clickSort()` / `assertSortAscending()` |
+| `TreeGrid` | `TreeGridElement` | `get(page)`, `expandRow()`, `collapseRow()`, `assertRowCount()`, `assertCellContent()` — extends `GridElement` |
+| `VirtualList` | `VirtualListElement` | `get(page)`, `assertRowCount()`, `assertItemRendered()`, `scrollToRow()` |
+| `Dialog` | `DialogElement` | `getByHeaderText(page, text)` or `new DialogElement(page)`, `assertOpen()`, `assertClosed()`, `assertHeaderText()`, `closeWithEscape()`, `getContentLocator()` |
+| `Notification` | `NotificationElement` | `getByText(page, text)`, `assertOpen()`, `assertClosed()`, `assertContent()` |
+| `Tabs` / `Tab` | `TabElement` | `getTabByText(tabsLocator, text)`, `getSelectedTab(tabsLocator)`, `select()`, `assertSelected()` |
+| `TabSheet` | `TabSheetElement` | `get(page)`, `selectTab(label)`, `getSelectedTab()`, `assertTabsCount()` |
+| `Accordion` | `AccordionElement` | `new AccordionElement(locator)`, `openPanel(summary)`, `closePanel(summary)`, `assertPanelOpened()`, `assertPanelClosed()` |
+| `AccordionPanel` | `AccordionPanelElement` | `getAccordionPanelBySummary(locator, summary)`, `assertOpened()`, `assertClosed()` |
+| `Details` | `DetailsElement` | `getBySummaryText(page, summary)`, `setOpen(boolean)`, `assertOpened()`, `assertClosed()` |
+| `MenuBar` | `MenuBarElement` | `getByLabel(page, label)` or `new MenuBarElement(page)`, `getMenuItemElement(name)`, `openSubMenu(name)` |
+| `ContextMenu` | `ContextMenuElement` | `ContextMenuElement.openOn(target)` then `new ContextMenuElement(page)`, `selectItem()`, `assertOpen()`, `assertClosed()` |
+| `SplitLayout` | `SplitLayoutElement` | `get(page)`, `assertHorizontal()`, `assertVertical()`, `dragSplitterBy()` |
+| `Upload` | `UploadElement` | `getByButtonText(page, text)`, `uploadFiles(Path...)`, `assertHasFile()`, `assertFileComplete()` |
+| `ProgressBar` | `ProgressBarElement` | `new ProgressBarElement(locator)`, `assertValue()`, `assertIndeterminate()` |
+| `Avatar` | `AvatarElement` | `get(page)`, `getByName(page, name)`, `assertName()`, `assertAbbreviation()` |
+| `MessageInput` | `MessageInputElement` | `get(page)`, `typeAndSubmit()`, `submit()`, `assertValue()` |
+| `MessageList` | `MessageListElement` | `get(page)`, `assertMessageCount()`, `assertMessageText(index, text)`, `assertMessageUserName(index, name)` |
+| `Popover` | `PopoverElement` | `getByLabel(page, label)` or `new PopoverElement(page)`, `assertOpen()`, `assertClosed()` |
+| `SideNavigation` | `SideNavigationElement` | `getByLabel(page, label)`, `clickItem(label)`, `getItem(label)`, `assertCollapsed()`, `assertExpanded()` |
+| `Card` | `CardElement` | `getByTitle(page, title)`, `assertTitle()`, `assertSubtitle()` |
 
 ## Factory method conventions
 
@@ -74,12 +75,18 @@ ButtonElement save = ButtonElement.getByText(page, "Save");
 NotificationElement toast = NotificationElement.getByText(page, "Saved");
 DialogElement dialog = DialogElement.getByHeaderText(page, "Confirm");
 
-// From a Locator — always available via the constructor
-// (useful for elements inside dialogs, grid cells, etc.)
+// A few elements have no static factory at all (AccordionElement,
+// ProgressBarElement, SideNavigationItemElement, ...) — construct them
+// from a Locator, which is always available on every element:
+// (also useful for elements inside dialogs, grid cells, etc.)
 TextFieldElement field = new TextFieldElement(dialog.getLocator().locator("vaadin-text-field"));
 ```
 
 ## Common shared assertions (available on most elements)
+
+Provided by `VaadinElement` and the shared mixins — an element only has a
+mixin's methods if it implements that mixin (see each element's **Implements**
+line in [api-reference.md](api-reference.md)).
 
 ```java
 element.assertVisible();

--- a/skills/vaadin-playwright-test/hooks/detect-dramafinder.sh
+++ b/skills/vaadin-playwright-test/hooks/detect-dramafinder.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# SessionStart hook installed with the vaadin-playwright-test plugin.
+#
+# Skill matching is a heuristic over whatever is in context: if a task (e.g.
+# a GitHub issue body) never mentions Vaadin, Playwright, or tests, nothing
+# signals the model to load the skill. This hook makes the signal come from
+# the environment instead — when the project declares a DramaFinder
+# dependency, it injects a standing reminder into the session context.
+if grep -qs '<artifactId>dramafinder</artifactId>' pom.xml */pom.xml 2>/dev/null; then
+  cat <<'EOF'
+This project depends on the DramaFinder Playwright testing library. For any
+integration/IT test work (writing, editing, or running tests for Vaadin
+views), load the vaadin-playwright-test skill before writing the test.
+EOF
+fi
+exit 0

--- a/skills/vaadin-playwright-test/hooks/hooks.json
+++ b/skills/vaadin-playwright-test/hooks/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/detect-dramafinder.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/skills/vaadin-playwright-test/setup.md
+++ b/skills/vaadin-playwright-test/setup.md
@@ -35,7 +35,6 @@ Two edits, both in `pom.xml`:
 Inside `<properties>`, add:
 
 ```xml
-
 <dramafinder.version>RESOLVED_VERSION</dramafinder.version>
 ```
 
@@ -47,7 +46,6 @@ Replace `RESOLVED_VERSION` with the value from Step 1. If a
 Inside `<dependencies>`, add (skip whichever is already present):
 
 ```xml
-
 <dependency>
     <groupId>com.microsoft.playwright</groupId>
     <artifactId>playwright</artifactId>
@@ -55,10 +53,10 @@ Inside `<dependencies>`, add (skip whichever is already present):
 </dependency>
 
 <dependency>
-<groupId>org.vaadin.addons</groupId>
-<artifactId>dramafinder</artifactId>
-<version>${dramafinder.version}</version>
-<scope>test</scope>
+    <groupId>org.vaadin.addons</groupId>
+    <artifactId>dramafinder</artifactId>
+    <version>${dramafinder.version}</version>
+    <scope>test</scope>
 </dependency>
 ```
 

--- a/skills/vaadin-playwright-test/setup.md
+++ b/skills/vaadin-playwright-test/setup.md
@@ -81,7 +81,24 @@ Otherwise:
 5. **Write** the result to
    `src/test/java/<basePackage-as-path>/it/support/SpringPlaywrightIT.java`.
 
-## Step 4 — Confirm dependencies resolve
+## Step 4 — Add a CLAUDE.md pointer
+
+Skill matching is heuristic: a future task that never mentions Vaadin,
+Playwright, or tests won't trigger the skill on its own. A standing pointer in
+the project's `CLAUDE.md` fixes that (it is loaded into context every session).
+
+Skip this step if `CLAUDE.md` already mentions `vaadin-playwright-test`.
+Otherwise append to `CLAUDE.md` (create the file if it doesn't exist):
+
+```markdown
+## Integration testing
+
+This project uses DramaFinder for Playwright integration tests. For any
+integration/IT test work (writing, editing, or running tests for Vaadin
+views), use the `vaadin-playwright-test` skill.
+```
+
+## Step 5 — Confirm dependencies resolve
 
 Optional but recommended: run `mvn -q dependency:resolve` to surface any pom
 syntax errors before generating tests. Skip if the user wants to proceed without

--- a/tile.json
+++ b/tile.json
@@ -1,6 +1,6 @@
 {
   "name": "dramafinder/vaadin-playwright-test",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": false,
   "summary": "Generate Playwright integration tests for Vaadin 25 views using the DramaFinder library. Use when the user wants to write IT tests for a Vaadin view, mentions DramaFinder, or asks about Playwright testing in a Vaadin project.",
   "skills": {


### PR DESCRIPTION
## Summary

Three related changes to make the `vaadin-playwright-test` skill fire and behave correctly:

1. **Broaden the skill trigger description** so it also matches indirect requests — GitHub issues, PRs, specs, "fix the failing test" — not just direct mentions of DramaFinder/Playwright.

2. **Add deterministic trigger signals for tasks that never mention Vaadin/tests at all.** Description matching is a heuristic over context; if nothing in the prompt or read files hints at testing, no wording helps. So:
   - a `SessionStart` plugin hook greps `pom.xml` for the `dramafinder` artifact and, on a hit, injects a standing reminder to use the skill for any IT test work;
   - the setup runbook now appends an equivalent pointer to the consuming project's `CLAUDE.md`, covering sessions where the plugin hook isn't active.
   - plugin version bumped to 0.3.0.

3. **Fix documentation inaccuracies found in review:**
   - `element-mapping.md`: the Key Methods column listed many methods that don't exist (`selectByText`, `clickRow`, `sortByColumn`, `assertUnchecked`, `sendMessage`, `uploadFile`, wrong `get(page)` factories on Dialog/Details/Card/MenuBar/…). Every entry is now verified against the auto-generated `api-reference.md`.
   - `SKILL.md`: fixed wrong wrapper calls in the raw-locator guidance, restored the formatter-mangled Java example blocks, documented the `MainView`/`Main` → root route mapping, added a version-drift caveat for the bundled API reference, and made Steps 4–5 write/run without confirmation during autonomous execution so the broadened trigger doesn't stall unattended agents.
   - `setup.md`: cleaned up malformed XML snippets.
   - `TESTING.md`: page objects described by library package instead of a source path that only exists inside this repo.

## Test plan

- [x] Hook emits the reminder in a project whose pom declares the dramafinder artifact; silent (exit 0) elsewhere
- [ ] Install the plugin from the marketplace and confirm the SessionStart hook runs
- [ ] CI's api-reference index check still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)