### PR TITLE
Add read-only assertions via HasReadOnlyElement mixin (#113)

### DIFF
--- a/skills/vaadin-playwright-test/api-reference.md
+++ b/skills/vaadin-playwright-test/api-reference.md
@@ -1,7 +1,7 @@
 # DramaFinder API Reference
 
 > **Auto-generated from source — do not edit by hand.** Regenerate with `jbang tools/generate-api-reference.java`.
-> DramaFinder 1.1.3-SNAPSHOT — 42 element wrappers.
+> DramaFinder 1.1.6-SNAPSHOT — 42 element wrappers.
 
 Complete public API of every DramaFinder element wrapper. Each element lists the shared mixin interfaces it implements; those interfaces' methods are documented once under **Shared mixins** at the end (not repeated per element). Method one-liners come from Javadoc.
 
@@ -274,7 +274,7 @@ PlaywrightElement for <vaadin-checkbox>.
 PlaywrightElement for <vaadin-combo-box>.
 
 **Extends:** VaadinElement  
-**Implements:** FocusableElement, HasAriaLabelElement, HasInputFieldElement, HasPrefixElement, HasThemeElement, HasPlaceholderElement, HasEnabledElement, HasTooltipElement, HasValidationPropertiesElement, HasClearButtonElement, HasAllowedCharPatternElement  
+**Implements:** FocusableElement, HasAriaLabelElement, HasInputFieldElement, HasPrefixElement, HasThemeElement, HasPlaceholderElement, HasEnabledElement, HasTooltipElement, HasValidationPropertiesElement, HasClearButtonElement, HasAllowedCharPatternElement, HasReadOnlyElement  
 
 **Constants:** `String FIELD_TAG_NAME = "vaadin-combo-box"`, `String FIELD_ITEM_TAG_NAME = "vaadin-combo-box-item"`
 
@@ -298,9 +298,6 @@ PlaywrightElement for <vaadin-combo-box>.
 - `boolean isOpened()` — Whether the overlay is currently open.
 - `void assertOpened()` — Assert that the combo box overlay is open.
 - `void assertClosed()` — Assert that the combo box overlay is closed.
-- `boolean isReadOnly()` — Whether the combo box is read-only.
-- `void assertReadOnly()` — Assert that the combo box is read-only.
-- `void assertNotReadOnly()` — Assert that the combo box is not read-only.
 - `Locator getToggleButtonLocator()` — Locator for the toggle button part.
 - `void clickToggleButton()` — Click the dropdown toggle button.
 - `int getOverlayItemCount()` — Count visible overlay items.
@@ -811,7 +808,7 @@ PlaywrightElement for <vaadin-message-list>.
 PlaywrightElement for <vaadin-multi-select-combo-box>.
 
 **Extends:** VaadinElement  
-**Implements:** FocusableElement, HasAriaLabelElement, HasInputFieldElement, HasThemeElement, HasPlaceholderElement, HasEnabledElement, HasTooltipElement, HasValidationPropertiesElement, HasClearButtonElement, HasAllowedCharPatternElement  
+**Implements:** FocusableElement, HasAriaLabelElement, HasInputFieldElement, HasThemeElement, HasPlaceholderElement, HasEnabledElement, HasTooltipElement, HasValidationPropertiesElement, HasClearButtonElement, HasAllowedCharPatternElement, HasReadOnlyElement  
 
 **Constants:** `String FIELD_TAG_NAME = "vaadin-multi-select-combo-box"`, `String FIELD_ITEM_TAG_NAME = "vaadin-multi-select-combo-box-item"`, `String FIELD_CHIP_TAG_NAME = "vaadin-multi-select-combo-box-chip"`
 
@@ -838,9 +835,6 @@ PlaywrightElement for <vaadin-multi-select-combo-box>.
 - `boolean isOpened()` — Whether the overlay is currently open.
 - `void assertOpened()` — Assert that the combo box overlay is open.
 - `void assertClosed()` — Assert that the combo box overlay is closed.
-- `boolean isReadOnly()` — Whether the combo box is read-only.
-- `void assertReadOnly()` — Assert that the combo box is read-only.
-- `void assertNotReadOnly()` — Assert that the combo box is not read-only.
 - `Locator getToggleButtonLocator()` — Locator for the toggle button part.
 - `void clickToggleButton()` — Click the dropdown toggle button.
 - `int getOverlayItemCount()` — Count visible overlay items.
@@ -1178,7 +1172,7 @@ PlaywrightElement for <vaadin-text-area>.
 PlaywrightElement for <vaadin-text-field>
 
 **Extends:** VaadinElement  
-**Implements:** HasValidationPropertiesElement, HasInputFieldElement, HasPrefixElement, HasSuffixElement, HasClearButtonElement, HasPlaceholderElement, HasAllowedCharPatternElement, HasThemeElement, FocusableElement, HasAriaLabelElement, HasEnabledElement, HasTooltipElement  
+**Implements:** HasValidationPropertiesElement, HasInputFieldElement, HasPrefixElement, HasSuffixElement, HasClearButtonElement, HasPlaceholderElement, HasAllowedCharPatternElement, HasThemeElement, FocusableElement, HasAriaLabelElement, HasEnabledElement, HasReadOnlyElement, HasTooltipElement  
 
 **Constants:** `String FIELD_TAG_NAME = "vaadin-text-field"`, `String MAXLENGTH_ATTRIBUTE = "maxlength"`, `String PATTERN_ATTRIBUTE = "pattern"`, `String MIN_LENGTH_ATTRIBUTE = "minLength"`
 
@@ -1477,6 +1471,23 @@ Utilities to interact with components implementing Vaadin's HasPrefix(slot="pref
 - `Locator getPrefixLocator()` — Locator for the prefix slot content.
 - `String getPrefixText()` — Text content of the prefix slot.
 - `void assertPrefixHasText(String text)` — Assert that the prefix slot has the expected text, or is hidden when null.
+
+### HasReadOnlyElement
+
+Mixin for components that expose a read-only state through the reflected readonly attribute.
+
+**Extends:** HasLocatorElement  
+
+**Constants:** `String READONLY_ATTRIBUTE = "readonly"`
+
+**Methods:**
+
+- `Locator getReadOnlyLocator()` — Locator used to check the read-only state.
+- `boolean isReadOnly()` — Whether the component is read-only.
+- `boolean isReadOnly(boolean readOnly)` — Whether the component's read-only state matches the expected value.
+- `void assertReadOnly()` — Assert that the component is read-only.
+- `void assertReadOnly(boolean readOnly)` — Assert that the component is read-only (true) or not read-only (false).
+- `void assertNotReadOnly()` — Assert that the component is not read-only.
 
 ### HasStyleElement
 

--- a/src/main/java/org/vaadin/addons/dramafinder/element/ComboBoxElement.java
+++ b/src/main/java/org/vaadin/addons/dramafinder/element/ComboBoxElement.java
@@ -11,6 +11,7 @@ import org.vaadin.addons.dramafinder.element.shared.HasEnabledElement;
 import org.vaadin.addons.dramafinder.element.shared.HasInputFieldElement;
 import org.vaadin.addons.dramafinder.element.shared.HasPlaceholderElement;
 import org.vaadin.addons.dramafinder.element.shared.HasPrefixElement;
+import org.vaadin.addons.dramafinder.element.shared.HasReadOnlyElement;
 import org.vaadin.addons.dramafinder.element.shared.HasThemeElement;
 import org.vaadin.addons.dramafinder.element.shared.HasTooltipElement;
 import org.vaadin.addons.dramafinder.element.shared.HasValidationPropertiesElement;
@@ -29,7 +30,7 @@ public class ComboBoxElement extends VaadinElement
         implements FocusableElement, HasAriaLabelElement, HasInputFieldElement,
         HasPrefixElement, HasThemeElement, HasPlaceholderElement,
         HasEnabledElement, HasTooltipElement, HasValidationPropertiesElement,
-        HasClearButtonElement, HasAllowedCharPatternElement {
+        HasClearButtonElement, HasAllowedCharPatternElement, HasReadOnlyElement {
 
     public static final String FIELD_TAG_NAME = "vaadin-combo-box";
     public static final String FIELD_ITEM_TAG_NAME = "vaadin-combo-box-item";
@@ -171,29 +172,6 @@ public class ComboBoxElement extends VaadinElement
      */
     public void assertClosed() {
         assertThat(getLocator()).not().hasAttribute("opened", "");
-    }
-
-    /**
-     * Whether the combo box is read-only.
-     *
-     * @return {@code true} when read-only
-     */
-    public boolean isReadOnly() {
-        return getLocator().getAttribute("readonly") != null;
-    }
-
-    /**
-     * Assert that the combo box is read-only.
-     */
-    public void assertReadOnly() {
-        assertThat(getLocator()).hasAttribute("readonly", "");
-    }
-
-    /**
-     * Assert that the combo box is not read-only.
-     */
-    public void assertNotReadOnly() {
-        assertThat(getLocator()).not().hasAttribute("readonly", "");
     }
 
     /**

--- a/src/main/java/org/vaadin/addons/dramafinder/element/MultiSelectComboBoxElement.java
+++ b/src/main/java/org/vaadin/addons/dramafinder/element/MultiSelectComboBoxElement.java
@@ -16,6 +16,7 @@ import org.vaadin.addons.dramafinder.element.shared.HasClearButtonElement;
 import org.vaadin.addons.dramafinder.element.shared.HasEnabledElement;
 import org.vaadin.addons.dramafinder.element.shared.HasInputFieldElement;
 import org.vaadin.addons.dramafinder.element.shared.HasPlaceholderElement;
+import org.vaadin.addons.dramafinder.element.shared.HasReadOnlyElement;
 
 import org.vaadin.addons.dramafinder.element.shared.HasThemeElement;
 import org.vaadin.addons.dramafinder.element.shared.HasTooltipElement;
@@ -34,7 +35,7 @@ public class MultiSelectComboBoxElement extends VaadinElement
         implements FocusableElement, HasAriaLabelElement, HasInputFieldElement,
         HasThemeElement, HasPlaceholderElement,
         HasEnabledElement, HasTooltipElement, HasValidationPropertiesElement,
-        HasClearButtonElement, HasAllowedCharPatternElement {
+        HasClearButtonElement, HasAllowedCharPatternElement, HasReadOnlyElement {
 
     public static final String FIELD_TAG_NAME = "vaadin-multi-select-combo-box";
     public static final String FIELD_ITEM_TAG_NAME = "vaadin-multi-select-combo-box-item";
@@ -211,31 +212,6 @@ public class MultiSelectComboBoxElement extends VaadinElement
      */
     public void assertClosed() {
         assertThat(getLocator()).not().hasAttribute("opened", "");
-    }
-
-    // ── Read-only ──────────────────────────────────────────────────────
-
-    /**
-     * Whether the combo box is read-only.
-     *
-     * @return {@code true} when read-only
-     */
-    public boolean isReadOnly() {
-        return getLocator().getAttribute("readonly") != null;
-    }
-
-    /**
-     * Assert that the combo box is read-only.
-     */
-    public void assertReadOnly() {
-        assertThat(getLocator()).hasAttribute("readonly", "");
-    }
-
-    /**
-     * Assert that the combo box is not read-only.
-     */
-    public void assertNotReadOnly() {
-        assertThat(getLocator()).not().hasAttribute("readonly", "");
     }
 
     // ── Toggle button ──────────────────────────────────────────────────

--- a/src/main/java/org/vaadin/addons/dramafinder/element/TextFieldElement.java
+++ b/src/main/java/org/vaadin/addons/dramafinder/element/TextFieldElement.java
@@ -14,6 +14,7 @@ import org.vaadin.addons.dramafinder.element.shared.HasEnabledElement;
 import org.vaadin.addons.dramafinder.element.shared.HasInputFieldElement;
 import org.vaadin.addons.dramafinder.element.shared.HasPlaceholderElement;
 import org.vaadin.addons.dramafinder.element.shared.HasPrefixElement;
+import org.vaadin.addons.dramafinder.element.shared.HasReadOnlyElement;
 import org.vaadin.addons.dramafinder.element.shared.HasSuffixElement;
 import org.vaadin.addons.dramafinder.element.shared.HasThemeElement;
 import org.vaadin.addons.dramafinder.element.shared.HasTooltipElement;
@@ -28,7 +29,7 @@ import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertTha
 public class TextFieldElement extends VaadinElement
         implements HasValidationPropertiesElement, HasInputFieldElement,
         HasPrefixElement, HasSuffixElement, HasClearButtonElement, HasPlaceholderElement, HasAllowedCharPatternElement,
-        HasThemeElement, FocusableElement, HasAriaLabelElement, HasEnabledElement, HasTooltipElement {
+        HasThemeElement, FocusableElement, HasAriaLabelElement, HasEnabledElement, HasReadOnlyElement, HasTooltipElement {
 
     public static final String FIELD_TAG_NAME = "vaadin-text-field";
     public static final String MAXLENGTH_ATTRIBUTE = "maxlength";

--- a/src/main/java/org/vaadin/addons/dramafinder/element/shared/HasReadOnlyElement.java
+++ b/src/main/java/org/vaadin/addons/dramafinder/element/shared/HasReadOnlyElement.java
@@ -1,0 +1,49 @@
+package org.vaadin.addons.dramafinder.element.shared;
+
+import com.microsoft.playwright.Locator;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+/**
+ * Mixin for components that expose a read-only state through the reflected
+ * {@code readonly} attribute.
+ */
+public interface HasReadOnlyElement extends HasLocatorElement {
+
+    /** Attribute reflecting the read-only state. */
+    String READONLY_ATTRIBUTE = "readonly";
+
+    /** Locator used to check the read-only state. Defaults to root. */
+    default Locator getReadOnlyLocator() {
+        return getLocator();
+    }
+
+    /** Whether the component is read-only. */
+    default boolean isReadOnly() {
+        return getReadOnlyLocator().getAttribute(READONLY_ATTRIBUTE) != null;
+    }
+
+    /** Whether the component's read-only state matches the expected value. */
+    default boolean isReadOnly(boolean readOnly) {
+        return isReadOnly() == readOnly;
+    }
+
+    /** Assert that the component is read-only. */
+    default void assertReadOnly() {
+        assertThat(getReadOnlyLocator()).hasAttribute(READONLY_ATTRIBUTE, "");
+    }
+
+    /** Assert that the component is read-only (true) or not read-only (false). */
+    default void assertReadOnly(boolean readOnly) {
+        if (readOnly) {
+            assertReadOnly();
+        } else {
+            assertNotReadOnly();
+        }
+    }
+
+    /** Assert that the component is not read-only. */
+    default void assertNotReadOnly() {
+        assertThat(getReadOnlyLocator()).not().hasAttribute(READONLY_ATTRIBUTE, "");
+    }
+}

--- a/src/test/java/org/vaadin/addons/dramafinder/tests/it/TextFieldViewIT.java
+++ b/src/test/java/org/vaadin/addons/dramafinder/tests/it/TextFieldViewIT.java
@@ -222,6 +222,20 @@ public class TextFieldViewIT extends SpringPlaywrightIT {
     }
 
     @Test
+    public void testReadOnly() {
+        TextFieldElement textfield = TextFieldElement.getByLabel(page, "Read-only Field");
+        textfield.assertReadOnly();
+        textfield.assertReadOnly(true);
+        assertEquals(true, textfield.isReadOnly());
+
+        page.locator("#toggle-read-only-button").click();
+
+        textfield.assertNotReadOnly();
+        textfield.assertReadOnly(false);
+        assertEquals(false, textfield.isReadOnly());
+    }
+
+    @Test
     public void testLabel() {
         TextFieldElement textfieldWithLabel = TextFieldElement.getByLabel(page, "Textfield");
         textfieldWithLabel.assertVisible();

--- a/src/test/java/org/vaadin/addons/dramafinder/tests/testuis/TextFieldView.java
+++ b/src/test/java/org/vaadin/addons/dramafinder/tests/testuis/TextFieldView.java
@@ -25,6 +25,17 @@ public class TextFieldView extends Main {
         createTextFieldWithAriaLabel();
         createTextFieldWithAriaLabelledBy();
         createEnabledDisabledExample();
+        createReadOnlyExample();
+    }
+
+    private void createReadOnlyExample() {
+        TextField textfield = new TextField("Read-only Field");
+        textfield.setValue("Read-only value");
+        textfield.setReadOnly(true);
+        Button button = new Button("Toggle read-only");
+        button.setId("toggle-read-only-button");
+        button.addClickListener(e -> textfield.setReadOnly(!textfield.isReadOnly()));
+        addExample("Read-only Example", new HorizontalLayout(textfield, button));
     }
 
     private void createTextFieldWithThemeExample() {


### PR DESCRIPTION
Fixes #113.

## Problem

Asserting a field's read-only state required a raw property check:

```java
TextFieldElement orderId = TextFieldElement.getByLabel(page, "Order Id");
assertEquals(Boolean.TRUE, orderId.getProperty("readonly"));
```

## Change

Introduces a shared `HasReadOnlyElement` mixin (following the existing `HasEnabledElement` pattern) so fields expose first-class read-only helpers:

- `isReadOnly()`, `isReadOnly(boolean)`
- `assertReadOnly()`, `assertReadOnly(boolean)`, `assertNotReadOnly()`

The issue's example becomes:

```java
TextFieldElement orderId = TextFieldElement.getByLabel(page, "Order Id");
orderId.assertReadOnly();
```

### Details

- `TextFieldElement` implements the mixin — inherited automatically by `PasswordFieldElement`, `EmailFieldElement`, and `TextAreaElement`.
- `ComboBoxElement` and `MultiSelectComboBoxElement` had duplicated read-only methods; they now use the shared mixin (behavior unchanged).
- Added a "Read-only Example" (with a toggle button) to `TextFieldView` and a `testReadOnly` IT.

## Testing

- `mvn test-compile` passes.
- New `TextFieldViewIT#testReadOnly` passes.
- Existing `ComboBoxViewIT#testReadOnly` / `MultiSelectComboBoxViewIT#testReadOnly` still pass after the refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)